### PR TITLE
bunp nix build to ghc 8.10.4

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 # Looks like release-20.03 doesn't have haskell-language-server so stick
 # with nixpkgs-unstable
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc8103" }:
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc8104" }:
 
 let
   # sources = import nix/sources.nix;

--- a/shell.nix
+++ b/shell.nix
@@ -1,2 +1,2 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc8103" }:
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc8104" }:
 (import ./default.nix { inherit nixpkgs compiler; }).shell


### PR DESCRIPTION
I really should use niv.