### PR TITLE
Bump to 0.4 to support aeson 2.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for vega-view
 
+## 0.4.0.0
+
+Support aeson 2.0. There is no functional change worthy of a major
+version but let's do it anysay!
+
 ## 0.3.1.7
 
 Bump aeson and scotty dependencies and try Yet-Another-Nix setup.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {-
@@ -31,7 +32,13 @@ The code could be refactored to be a SPA, but does it need to be?
 module Main where
 
 import qualified Data.ByteString.Lazy.Char8 as LB8
+
+#if MIN_VERSION_aeson(2, 0, 0)
+import qualified Data.Aeson.KeyMap as KeyMap
+#else
 import qualified Data.HashMap.Strict as HM
+#endif
+
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.IO as LT
@@ -42,6 +49,7 @@ import qualified Text.Blaze.Html5.Attributes as A
 import Control.Exception (IOException, try)
 import Control.Monad (forM_, unless)
 import Control.Monad.IO.Class (liftIO)
+
 import Data.Aeson (Value(String, Object), Object
                   , (.=)
                   , eitherDecode', encode, object)
@@ -106,7 +114,13 @@ createView ::
 createView spec specId =
   let vis = specVis spec
 
-      mDesc = case HM.lookup "description" vis of
+      -- Must be a better way to deal with this change in aeson-2.0
+#if MIN_VERSION_aeson(2, 0, 0)
+      getDesc = KeyMap.lookup "description" vis
+#else
+      getDesc = HM.lookup "description" vis
+#endif
+      mDesc = case getDesc of
                 Just (String d) -> Just d
                 _ -> Nothing
 

--- a/stack-8.10.yaml
+++ b/stack-8.10.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.0
+resolver: lts-18.13
 
 packages:
 - .

--- a/stack-9.0.yaml
+++ b/stack-9.0.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2021-06-21
+resolver: nightly-2021-10-13
 
 packages:
 - .

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,11 @@
-resolver: lts-18.0
+resolver: lts-18.13
 
 packages:
 - .
+
+extra-deps:
+- aeson-2.0.1.0
+- semialign-1.2
+- time-compat-1.9.6.1
+- hashable-1.3.4.1
+- scotty-0.12

--- a/vega-view.cabal
+++ b/vega-view.cabal
@@ -1,5 +1,5 @@
 name:           vega-view
-version:        0.3.1.7
+version:        0.4.0.0
 synopsis:       Easily view Vega or Vega-Lite visualizations.
 description:    A web server that is used to view all the Vega and Vega-Lite
                 specifications in a directory, or sub-directory. It is similar
@@ -35,7 +35,7 @@ executable vegaview
       app
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-                aeson >= 1.1 && < 1.6
+                aeson >= 1.1 && < 2.1
               , base >= 4.9 && <5
               , blaze-html >= 0.7 && < 0.10
               , blaze-markup >= 0.6 && < 0.9


### PR DESCRIPTION
The jump in the major version number isn't really needed here (as
this is an executable) but as the aeson change is a rather large
one for the Haskell ecosystem let's bump the version.